### PR TITLE
Fix up large data input and send stop signals

### DIFF
--- a/src/Patches/WSManAPIDataCommon.cs
+++ b/src/Patches/WSManAPIDataCommon.cs
@@ -1,6 +1,6 @@
+using HarmonyLib;
 using System;
 using System.Management.Automation.Remoting.Client;
-using HarmonyLib;
 
 namespace PSWSMan.Patches;
 

--- a/src/Patches/WSManClientCommandTransportManager.cs
+++ b/src/Patches/WSManClientCommandTransportManager.cs
@@ -1,8 +1,9 @@
+using HarmonyLib;
 using System;
 using System.Management.Automation;
 using System.Management.Automation.Remoting;
 using System.Management.Automation.Remoting.Client;
-using HarmonyLib;
+using System.Reflection;
 
 namespace PSWSMan.Patches;
 
@@ -11,31 +12,52 @@ namespace PSWSMan.Patches;
 [HarmonyPatch(nameof(WSManClientCommandTransportManager.CreateAsync))]
 internal static class Pwsh_WSManClientCommandTransportManagerCreateAsync
 {
-    static bool Prefix(WSManClientCommandTransportManager __instance, IntPtr ____wsManShellOperationHandle,
-        SerializedDataStream ___serializedPipeline, WSManClientSessionTransportManager ____sessnTm,
-        Guid ___powershellInstanceId, PSTraceSource ___tracer)
+    static bool Prefix(WSManClientCommandTransportManager __instance, SerializedDataStream ___serializedPipeline,
+        WSManClientSessionTransportManager ____sessnTm, Guid ___powershellInstanceId, PSTraceSource ___tracer)
     {
-        WSManPSRPShim session = WSManCompatState.SessionInfo[____sessnTm.SessionHandle];
-        byte[] cmdPart1 = ___serializedPipeline.ReadOrRegisterCallback(null) ?? Array.Empty<byte>();
+        /*
+            Called when a pipeline is to be created. This simply does:
+            - Sends the WSMan Command payload
+            - Starts a new thread with a receive task
+            - Sends remaining data (if any)
+        */
+        ___tracer.WriteLine("PSWSMan: WSManClientCommandTransportManager.CreateAsync - Called");
 
         try
         {
-            session.CreateCommandAsync(___powershellInstanceId, cmdPart1).GetAwaiter().GetResult();
+            WSManPSRPShim session = WSManCompatState.SessionInfo[____sessnTm.SessionHandle];
+            byte[] cmdPart1 = ___serializedPipeline.ReadOrRegisterCallback(null) ?? Array.Empty<byte>();
+
+            ___tracer.WriteLine(
+                "PSWSMan: WSManClientCommandTransportManager.CreateAsync - Sending Command Create for {0} CmdId {1}",
+                session.RunspacePoolId, ___powershellInstanceId);
+            try
+            {
+                session.CreateCommandAsync(___powershellInstanceId, cmdPart1).GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                ___tracer.WriteLine(
+                    "PSWSMan: WSManClientCommandTransportManager.CreateAsync - Shell Command failed for {0} CmdId {1}\n{2}",
+                    session.RunspacePoolId, ___powershellInstanceId, e);
+
+                TransportErrorOccuredEventArgs err = new(new PSRemotingTransportException(e.Message, e),
+                    TransportMethodEnum.RunShellCommandEx);
+                __instance.ProcessWSManTransportError(err);
+                return false;
+            }
+
+            session.StartReceiveTask(__instance, ___tracer, commandId: ___powershellInstanceId);
+
+            typeof(WSManClientCommandTransportManager).GetMethod(
+                "SendOneItem",
+                BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.Invoke(__instance, Array.Empty<Type>());
         }
         catch (Exception e)
         {
-            TransportErrorOccuredEventArgs err = new(new PSRemotingTransportException(e.Message, e),
-                TransportMethodEnum.RunShellCommandEx);
-            __instance.ProcessWSManTransportError(err);
+            ___tracer.WriteLine("PSWSMan: WSManClientCommandTransportManager.CreateAsync - Error\n{0}", e.ToString());
         }
-
-        session.StartReceiveTask(__instance, ___tracer, commandId: ___powershellInstanceId);
-
-        // FIXME: Send more packets if available
-        // __instance.SendOneItem();
-        //byte[]? data = ___dataToBeSent.ReadOrRegisterCallback(____onDataAvailableToSendCallback, out _);
-
-        // SendOneItem
 
         return false;
     }
@@ -45,8 +67,46 @@ internal static class Pwsh_WSManClientCommandTransportManagerCreateAsync
 [HarmonyPatch(nameof(WSManClientCommandTransportManager.SendStopSignal))]
 internal static class Pwsh_WSmanClientCommandTransportManagerSendStopSignal
 {
-    static bool Prefix(WSManClientCommandTransportManager __instance)
+    static bool Prefix(WSManClientCommandTransportManager __instance, WSManClientSessionTransportManager ____sessnTm,
+        Guid ___powershellInstanceId, PSTraceSource ___tracer)
     {
+        /*
+            Called when pwsh is attempting to stop a running pipeline.
+        */
+        ___tracer.WriteLine("PSWSMan: WSManClientCommandTransportManager.SendStopSignal - Called");
+
+        try
+        {
+            WSManPSRPShim session = WSManCompatState.SessionInfo[____sessnTm.SessionHandle];
+
+            ___tracer.WriteLine(
+                "PSWSMan: WSManClientCommandTransportManager.SendStopSignal - Sending Stop for {0} CmdId {1}",
+                session.RunspacePoolId, ___powershellInstanceId);
+            try
+            {
+                session.StopCommandAsync(___powershellInstanceId).GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                ___tracer.WriteLine(
+                    "PSWSMan: WSManClientCommandTransportManager.SendStopSignal - Send failed for {0} CmdId {1}\n{2}",
+                    session.RunspacePoolId, ___powershellInstanceId, e);
+
+                TransportErrorOccuredEventArgs err = new(new PSRemotingTransportException(e.Message, e),
+                    TransportMethodEnum.RunShellCommandEx);
+                __instance.ProcessWSManTransportError(err);
+                return false;
+            }
+
+            __instance.EnqueueAndStartProcessingThread(null, null, true);
+        }
+        catch (Exception e)
+        {
+            ___tracer.WriteLine("PSWSMan: WSManClientCommandTransportManager.SendStopSignal - Error\n{0}",
+                e.ToString());
+            throw;
+        }
+
         return false;
     }
 }
@@ -56,32 +116,53 @@ internal static class Pwsh_WSmanClientCommandTransportManagerSendStopSignal
 internal static class Pwsh_WSmanClientCommandTransportManagerCloseAsync
 {
     static bool Prefix(WSManClientCommandTransportManager __instance, WSManClientSessionTransportManager ____sessnTm,
-        Guid ___powershellInstanceId, object ___syncObject, ref bool ___isClosed)
+        Guid ___powershellInstanceId, PSTraceSource ___tracer, object ___syncObject, ref bool ___isClosed)
     {
-        lock (___syncObject)
-        {
-            if (___isClosed)
-            {
-                return false;
-            }
-
-            ___isClosed = true;
-        }
-        WSManPSRPShim session = WSManCompatState.SessionInfo[____sessnTm.SessionHandle];
-
+        /*
+            Called when a pipeline is being closed, WSMan needs to send the Terminal Signal to clear up any resources.
+        */
+        ___tracer.WriteLine("PSWSMan: WSManClientCommandTransportManager.CloseAsync - Called");
 
         try
         {
-            session.CloseCommandAsync(___powershellInstanceId).GetAwaiter().GetResult();
+            lock (___syncObject)
+            {
+                if (___isClosed)
+                {
+                    return false;
+                }
+
+                ___isClosed = true;
+            }
+
+            WSManPSRPShim session = WSManCompatState.SessionInfo[____sessnTm.SessionHandle];
+            ___tracer.WriteLine(
+                "PSWSMan: WSManClientCommandTransportManager.CloseAsync - Sending Stop for {0} CmdId {1}",
+                session.RunspacePoolId, ___powershellInstanceId);
+
+            try
+            {
+                session.CloseCommandAsync(___powershellInstanceId).GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                ___tracer.WriteLine(
+                    "PSWSMan: WSManClientCommandTransportManager.CloseAsync - Send failed for {0} CmdId {1}\n{2}",
+                    session.RunspacePoolId, ___powershellInstanceId, e);
+
+                TransportErrorOccuredEventArgs err = new(new PSRemotingTransportException(e.Message, e),
+                    TransportMethodEnum.RunShellCommandEx);
+                __instance.ProcessWSManTransportError(err);
+            }
+
+            __instance.RaiseCloseCompleted();
         }
         catch (Exception e)
         {
-            TransportErrorOccuredEventArgs err = new(new PSRemotingTransportException(e.Message, e),
-                TransportMethodEnum.RunShellCommandEx);
-            __instance.ProcessWSManTransportError(err);
+            ___tracer.WriteLine("PSWSMan: WSManClientCommandTransportManager.CloseAsync - Error\n{0}",
+                e.ToString());
+            throw;
         }
-
-        __instance.RaiseCloseCompleted();
 
         return false;
     }
@@ -91,11 +172,80 @@ internal static class Pwsh_WSmanClientCommandTransportManagerCloseAsync
 [HarmonyPatch(nameof(WSManClientCommandTransportManager.Dispose))]
 internal static class Pwsh_WSmanClientCommandTransportManagerDispose
 {
-    static bool Prefix(WSManClientCommandTransportManager __instance)
+    static bool Prefix(WSManClientCommandTransportManager __instance, PSTraceSource ___tracer)
     {
         /*
             Called after CloseAsync to free up any unmanaged resources. There's nothing to do in the patched method.
         */
+        ___tracer.WriteLine("PSWSMan: WSManClientCommandTransportManager.Dispose - Called");
+
+        return false;
+    }
+}
+
+[HarmonyPatch(typeof(WSManClientCommandTransportManager))]
+[HarmonyPatch("SendData")]
+internal static class Pwsh_WSmanClientCommandTransportManagerSendData
+{
+    static bool Prefix(WSManClientCommandTransportManager __instance, WSManClientSessionTransportManager ____sessnTm,
+        Guid ___powershellInstanceId, PSTraceSource ___tracer, byte[] data, DataPriorityType priorityType)
+    {
+        /*
+            Called after CloseAsync to free up any unmanaged resources. There's nothing to do in the patched method.
+        */
+        ___tracer.WriteLine("PSWSMan: WSManClientCommandTransportManager.SendData - Called");
+
+        try
+        {
+            WSManPSRPShim session = WSManCompatState.SessionInfo[____sessnTm.SessionHandle];
+
+            ___tracer.WriteLine(
+                "PSWSMan: WSManClientCommandTransportManager.SendData - Sending Data for {0} CmdId {1}",
+                session.RunspacePoolId, ___powershellInstanceId);
+            try
+            {
+                session.SendAsync(priorityType == DataPriorityType.Default ? "stdin" : "pr", data,
+                    commandId: ___powershellInstanceId).GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                ___tracer.WriteLine(
+                    "PSWSMan: WSManClientCommandTransportManager.SendData - Send failed for {0} CmdId {1}\n{2}",
+                    session.RunspacePoolId, ___powershellInstanceId, e);
+
+                TransportErrorOccuredEventArgs err = new(new PSRemotingTransportException(e.Message, e),
+                    TransportMethodEnum.RunShellCommandEx);
+                __instance.ProcessWSManTransportError(err);
+                return false;
+            }
+
+            typeof(WSManClientCommandTransportManager).GetMethod(
+                "SendOneItem",
+                BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.Invoke(__instance, Array.Empty<Type>());
+        }
+        catch (Exception e)
+        {
+            ___tracer.WriteLine("PSWSMan: WSManClientCommandTransportManager.SendData - Error\n{0}", e.ToString());
+            throw;
+        }
+
+        return false;
+    }
+}
+
+
+[HarmonyPatch(typeof(WSManClientCommandTransportManager))]
+[HarmonyPatch(nameof(WSManClientCommandTransportManager.StartReceivingData))]
+internal static class Pwsh_WSmanClientCommandTransportManagerStartReceivingData
+{
+    static bool Prefix(WSManClientCommandTransportManager __instance, PSTraceSource ___tracer)
+    {
+        /*
+            Called after CloseAsync to free up any unmanaged resources. There's nothing to do in the patched method.
+        */
+        ___tracer.WriteLine("PSWSMan: WSManClientCommandTransportManager.StartReceivingData - Called");
+
         return false;
     }
 }

--- a/src/Patches/WSManConnectionInfo.cs
+++ b/src/Patches/WSManConnectionInfo.cs
@@ -1,7 +1,7 @@
+using HarmonyLib;
 using System.Management.Automation;
 using System.Management.Automation.Remoting;
 using System.Management.Automation.Runspaces;
-using HarmonyLib;
 
 namespace PSWSMan.Patches;
 

--- a/src/PwshShim.cs
+++ b/src/PwshShim.cs
@@ -186,6 +186,12 @@ internal class WSManPSRPShim
         await _session.PostRequest<WSManSendResponse>(payload);
     }
 
+    public async Task StopCommandAsync(Guid commandId)
+    {
+        string payload = _session.WinRS.Signal(SignalCode.PSCtrlC, commandId: commandId);
+        await _session.PostRequest<WSManSignalResponse>(payload);
+    }
+
     public void StartReceiveTask(BaseClientTransportManager tm, PSTraceSource tracer, Guid? commandId = null)
     {
         _receiveThreads.Add(Task.Run(() =>


### PR DESCRIPTION
Fix up the patching required when either the runspace pool or pipeline has too much data to send in one fragment. Also fixes up the Stop signal messages for pipelines and add some extra tracing messages for debugging.