### PR TITLE
Prepare for net8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v3
 
+    # Needed until dotnet 8 is made final
+    - name: Setup dotnet SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+        dotnet-quality: 'preview'
+
     - name: OIDC Login to Azure
       if: ${{ env.BUILD_CONFIGURATION == 'Release' }}
       uses: azure/login@v1
@@ -72,6 +79,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+
+    # Needed until dotnet 8 is made final
+    - name: Setup dotnet SDK
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: '8.0.x'
+        dotnet-quality: 'preview'
 
     - name: Restore Built PowerShell Module
       uses: actions/download-artifact@v3

--- a/PSWSMan.build.ps1
+++ b/PSWSMan.build.ps1
@@ -77,16 +77,22 @@ task CopyToRelease {
     }
     Copy-Item @copyParams
 
+    $first = $true
     foreach ($framework in $TargetFrameworks) {
         $buildFolder = [IO.Path]::Combine($CSharpPath, 'bin', $Configuration, $framework, 'publish')
         $binFolder = [IO.Path]::Combine($ReleasePath, 'bin', $framework)
         if (-not (Test-Path -LiteralPath $binFolder)) {
             New-Item -Path $binFolder -ItemType Directory | Out-Null
         }
-        Copy-Item ([IO.Path]::Combine($buildFolder, "*")) -Destination $binFolder -Recurse
-        Remove-Item ([IO.Path]::Combine($binFolder, 'runtimes', 'android*')) -Recurse -Force
-        Remove-Item ([IO.Path]::Combine($binFolder, 'runtimes', 'ios*')) -Recurse -Force
-        Remove-Item ([IO.Path]::Combine($binFolder, 'runtimes', 'osx-universal')) -Recurse -Force
+        Copy-Item ([IO.Path]::Combine($buildFolder, "*")) -Destination $binFolder -Recurse -Exclude runtimes
+        if ($first) {
+            $first = $false
+            $runtimesDest = [IO.Path]::Combine($ReleasePath, 'bin')
+            Copy-Item ([IO.Path]::Combine($buildFolder, "runtimes")) -Destination $runtimesDest -Recurse
+            Remove-Item ([IO.Path]::Combine($runtimesDest, 'runtimes', 'android*')) -Recurse -Force
+            Remove-Item ([IO.Path]::Combine($runtimesDest, 'runtimes', 'ios*')) -Recurse -Force
+            Remove-Item ([IO.Path]::Combine($runtimesDest, 'runtimes', 'osx-universal')) -Recurse -Force
+        }
     }
 }
 

--- a/module/PSWSMan.psm1
+++ b/module/PSWSMan.psm1
@@ -6,7 +6,13 @@
 # that ALC.
 
 $moduleName = [System.IO.Path]::GetFileNameWithoutExtension($PSCommandPath)
-Add-Type -Path ([System.IO.Path]::Combine($PSScriptRoot, 'bin', 'net6.0', "$moduleName.dll"))
+$runtimeVersion = if ($PSVersionTable.PSVersion -gt [Version]'7.4') {
+    'net8.0'
+}
+else {
+    'net6.0'
+}
+Add-Type -Path ([System.IO.Path]::Combine($PSScriptRoot, 'bin', $runtimeVersion, "$moduleName.dll"))
 
 $mainModule = [PSWSMan.LoadContext]::Initialize()
 Import-Module -Assembly $mainModule

--- a/src/PSWSMan.Module/OnImportAndRemove.cs
+++ b/src/PSWSMan.Module/OnImportAndRemove.cs
@@ -61,6 +61,7 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
 
         string devolutionsPaths = Path.Combine(
             Path.GetDirectoryName(typeof(OnModuleImportAndRemove).Assembly.Location) ?? "",
+            "..",
             "runtimes",
             $"{osName}-{RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()}",
             "native",

--- a/src/PSWSMan.Module/PSWSMan.Module.csproj
+++ b/src/PSWSMan.Module/PSWSMan.Module.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <!--A conflict with IgnoredAccessChecksToGenerator and MonoMod fires this-->

--- a/src/PSWSMan/Connection.cs
+++ b/src/PSWSMan/Connection.cs
@@ -461,7 +461,11 @@ public class WSManConnection : IDisposable
                 if ((connection.SslOptions.ClientCertificates?.Count ?? 0) > 0)
                 {
                     // We only need to disable TLS Resume when dealing with client certificates.
+#if NET8_0_OR_GREATER
+                    connection.SslOptions.AllowTlsResume = false;
+#else
                     resetTlsResumeSetting = TlsSessionResumeSetting.DisableTlsSessionResume(sslStream);
+#endif
                 }
                 try
                 {

--- a/src/PSWSMan/PSWSMan.csproj
+++ b/src/PSWSMan/PSWSMan.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>PSWSMan</AssemblyName>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
While MonoMod does not currently support dotnet 8 this commit removes some reflection code around TLS resume now that dotnet has introduced a new option that can be set to disable TLS resume.